### PR TITLE
Improve the ECS clause system

### DIFF
--- a/internal/ecs/clause.go
+++ b/internal/ecs/clause.go
@@ -44,21 +44,4 @@ func All(t ComponentType) TypeClause { return TypeClause{All: t} }
 // Any is a convenience constructor.
 func Any(t ComponentType) TypeClause { return TypeClause{Any: t} }
 
-// Filter a list of entities under a given type clause.
-func Filter(ents []Entity, tcl TypeClause) []Entity {
-	i, j := 0, 0
-	for ; j < len(ents); j++ {
-		if tcl.Test(ents[j].Type()) {
-			if j > i {
-				ents[i] = ents[j]
-			}
-			i++
-		}
-	}
-	for j = i; j < len(ents); j++ {
-		ents[j] = NilEntity
-	}
-	return ents[:i]
-}
-
 // TODO: boolean logic methods?

--- a/internal/ecs/clause.go
+++ b/internal/ecs/clause.go
@@ -21,30 +21,29 @@ var (
 	FalseClause TypeClause = constClause(false)
 )
 
-// MatchAll return a clause that matches only if all of the type bits are set.
-// If the type is NoType, the clause never matches (always returns false).
-func (t ComponentType) MatchAll() TypeClause {
+// All return a clause that matches only if all of the type bits are set.  If
+// the type is NoType, the clause never matches (always returns false).
+func (t ComponentType) All() TypeClause {
 	if t == NoType {
 		return FalseClause
 	}
 	return allClause(t)
 }
 
-// MatchAny return a clause that matches only if at least one of the type bits
-// is set. If the type is NoType, the clause always matches (always returns
-// true).
-func (t ComponentType) MatchAny() TypeClause {
+// Any return a clause that matches only if at least one of the type bits is
+// set. If the type is NoType, the clause always matches (always returns true).
+func (t ComponentType) Any() TypeClause {
 	if t == NoType {
 		return TrueClause
 	}
 	return anyClause(t)
 }
 
-// MatchNotAll return a clause that matches only if at least one of the type bits is not set.
-func (t ComponentType) MatchNotAll() TypeClause { return notAllClause(t) }
+// NotAll return a clause that matches only if at least one of the type bits is not set.
+func (t ComponentType) NotAll() TypeClause { return notAllClause(t) }
 
-// MatchNotAny return a clause that matches only if none of the type bits are not set.
-func (t ComponentType) MatchNotAny() TypeClause { return notAnyClause(t) }
+// NotAny return a clause that matches only if none of the type bits are not set.
+func (t ComponentType) NotAny() TypeClause { return notAnyClause(t) }
 
 type constClause bool
 type allClause ComponentType

--- a/internal/ecs/clause.go
+++ b/internal/ecs/clause.go
@@ -1,47 +1,256 @@
 package ecs
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
-// TypeClause is a logical filter for ComponentTypes.  If All is non-0, then
-// Test()s true only for types that have all of those type bits set.
-// Similarly if Any non-0, then Test()s true only for types that have at least
-// one of those type bits set.
-type TypeClause struct {
-	All ComponentType
-	Any ComponentType
+// TypeClause is a logical filter for ComponentTypes.
+type TypeClause interface {
+	test(ComponentType) bool
+	// TODO this is a convenient place to start, but to make it perform, we'll
+	// need to compile to a tighter for linear scan and/or to proper planning
+	// wrt available indexing.
 }
 
-func (tcl TypeClause) String() string {
-	if tcl.All == 0 {
-		return fmt.Sprintf("Any(%v)", tcl.Any)
+var (
+	// TrueClause matches any type.
+	TrueClause TypeClause = constClause(true)
+
+	// FalseClause matches no type.
+	FalseClause TypeClause = constClause(false)
+)
+
+// MatchAll return a clause that matches only if all of the type bits are set.
+// If the type is NoType, the clause never matches (always returns false).
+func (t ComponentType) MatchAll() TypeClause {
+	if t == NoType {
+		return FalseClause
 	}
-	if tcl.Any == 0 {
-		return fmt.Sprintf("All(%v)", tcl.All)
-	}
-	return fmt.Sprintf("Clause(%v, %v)", tcl.All, tcl.Any)
+	return allClause(t)
 }
 
-// Test returns true/or false based on above logic description.
-func (tcl TypeClause) Test(t ComponentType) bool {
-	if tcl.All != 0 && !t.All(tcl.All) {
-		return false
+// MatchAny return a clause that matches only if at least one of the type bits
+// is set. If the type is NoType, the clause always matches (always returns
+// true).
+func (t ComponentType) MatchAny() TypeClause {
+	if t == NoType {
+		return TrueClause
 	}
-	if tcl.Any != 0 && !t.Any(tcl.Any) {
-		return false
+	return anyClause(t)
+}
+
+// MatchNotAll return a clause that matches only if at least one of the type bits is not set.
+func (t ComponentType) MatchNotAll() TypeClause { return notAllClause(t) }
+
+// MatchNotAny return a clause that matches only if none of the type bits are not set.
+func (t ComponentType) MatchNotAny() TypeClause { return notAnyClause(t) }
+
+type constClause bool
+type allClause ComponentType
+type anyClause ComponentType
+type notAllClause ComponentType
+type notAnyClause ComponentType
+type andClause []TypeClause
+type orClause []TypeClause
+
+func (cc constClause) String() string { return fmt.Sprintf("%v", bool(cc)) }
+func (t allClause) String() string    { return fmt.Sprintf("All(%v)", ComponentType(t)) }
+func (t anyClause) String() string    { return fmt.Sprintf("Any(%v)", ComponentType(t)) }
+func (t notAllClause) String() string { return fmt.Sprintf("NotAll(%v)", ComponentType(t)) }
+func (t notAnyClause) String() string { return fmt.Sprintf("NotAny(%v)", ComponentType(t)) }
+func (tcls andClause) String() string {
+	ss := make([]string, len(tcls))
+	for i := range tcls {
+		ss = append(ss, fmt.Sprint(tcls[i]))
+	}
+	return fmt.Sprintf("And(%s)", strings.Join(ss, " "))
+}
+func (tcls orClause) String() string {
+	ss := make([]string, len(tcls))
+	for i := range tcls {
+		ss = append(ss, fmt.Sprint(tcls[i]))
+	}
+	return fmt.Sprintf("Or(%s)", strings.Join(ss, " "))
+}
+
+func (cc constClause) test(ComponentType) bool    { return bool(cc) }
+func (t allClause) test(ot ComponentType) bool    { return ot&ComponentType(t) == ComponentType(t) }
+func (t anyClause) test(ot ComponentType) bool    { return ot&ComponentType(t) != 0 }
+func (t notAllClause) test(ot ComponentType) bool { return ot&ComponentType(t) != ComponentType(t) }
+func (t notAnyClause) test(ot ComponentType) bool { return ot&ComponentType(t) == 0 }
+func (tcls andClause) test(ot ComponentType) bool {
+	for i := range tcls {
+		if !tcls[i].test(ot) {
+			return false
+		}
 	}
 	return true
 }
+func (tcls orClause) test(ot ComponentType) bool {
+	for i := range tcls {
+		if tcls[i].test(ot) {
+			return true
+		}
+	}
+	return false
+}
 
-// AllClause matches any type; always Test()s true.
-var AllClause = TypeClause{}
+// And returns a type clause that matches only if all of its component clauses
+// match.
+func And(tcls ...TypeClause) TypeClause {
+	if len(tcls) == 0 {
+		return FalseClause
+	}
+	for len(tcls) > 1 {
+		tcl := and(tcls[0], tcls[1])
+		if tcl == nil {
+			tcl = andClause{tcls[0], tcls[1]}
+		}
+		tcls = tcls[1:]
+		tcls[0] = tcl
+	}
+	return tcls[0]
+}
 
-// Clause is a convenience constructor.
-func Clause(all, any ComponentType) TypeClause { return TypeClause{all, any} }
+// Or returns a type clause that matches only if any of its component clauses
+// match.
+func Or(tcls ...TypeClause) TypeClause {
+	if len(tcls) == 0 {
+		return TrueClause
+	}
+	for len(tcls) > 1 {
+		tcl := or(tcls[0], tcls[1])
+		if tcl == nil {
+			tcl = orClause{tcls[0], tcls[1]}
+		}
+		tcls = tcls[1:]
+		tcls[0] = tcl
+	}
+	return tcls[0]
+}
 
-// All is a convenience constructor.
-func All(t ComponentType) TypeClause { return TypeClause{All: t} }
+func and(a, b TypeClause) TypeClause {
+	if _, ok := b.(constClause); ok {
+		return and(b, a)
+	}
+	if cc, ok := a.(constClause); ok {
+		if bool(cc) {
+			return b
+		}
+		return FalseClause
+	}
 
-// Any is a convenience constructor.
-func Any(t ComponentType) TypeClause { return TypeClause{Any: t} }
+	// all(a) && all(b) = all(a|b)
+	if allA, ok := a.(allClause); ok {
+		if allB, ok := b.(allClause); ok {
+			return allClause(allA | allB)
+		}
+	}
 
-// TODO: boolean logic methods?
+	// notAny(a) && notAny(b) = notAny(a|b)
+	if notAnyA, ok := a.(notAnyClause); ok {
+		if notAnyB, ok := b.(notAnyClause); ok {
+			return notAnyClause(notAnyA | notAnyB)
+		}
+	}
+
+	if tclsA, ok := a.(andClause); ok {
+		r := append(andClause(nil), tclsA...)
+		tclsB, ok := b.(andClause)
+		if !ok {
+			tclsB = andClause{b}
+		}
+		for _, b := range tclsB {
+			for i := range r {
+				if tcl := and(r[i], b); tcl != nil {
+					r[i] = tcl
+					continue
+				}
+			}
+			r = append(r, b)
+		}
+		return r
+	}
+
+	return nil
+}
+
+func or(a, b TypeClause) TypeClause {
+	if _, ok := b.(constClause); ok {
+		return or(b, a)
+	}
+	if cc, ok := a.(constClause); ok {
+		if bool(cc) {
+			return TrueClause
+		}
+		return b
+	}
+
+	// any(a) || any(b) = any(a&b)
+	if anyA, ok := a.(anyClause); ok {
+		if anyB, ok := b.(anyClause); ok {
+			return anyClause(anyA & anyB)
+		}
+	}
+
+	// notAll(a) || notAll(b) = notAll(a&b)
+	if notAllA, ok := a.(notAllClause); ok {
+		if notAllB, ok := b.(notAllClause); ok {
+			return notAllClause(notAllA & notAllB)
+		}
+	}
+
+	if tclsA, ok := a.(orClause); ok {
+		r := append(orClause(nil), tclsA...)
+		tclsB, ok := b.(orClause)
+		if !ok {
+			tclsB = orClause{b}
+		}
+		for _, b := range tclsB {
+			for i := range r {
+				if tcl := or(r[i], b); tcl != nil {
+					r[i] = tcl
+					continue
+				}
+			}
+			r = append(r, b)
+		}
+		return r
+	}
+
+	return nil
+}
+
+// Not returns a type clause that matches only the given clause does not match.
+func Not(tcl TypeClause) TypeClause {
+	switch val := tcl.(type) {
+	case constClause:
+		if bool(val) {
+			return FalseClause
+		}
+		return TrueClause
+	case allClause:
+		return notAllClause(val)
+	case anyClause:
+		return notAnyClause(val)
+	case notAllClause:
+		return allClause(val)
+	case notAnyClause:
+		return anyClause(val)
+	case andClause:
+		nor := make(orClause, len(val))
+		for i := range val {
+			nor[i] = Not(val[i])
+		}
+		return nor
+	case orClause:
+		nand := make(andClause, len(val))
+		for i := range val {
+			nand[i] = Not(val[i])
+		}
+		return nand
+	default:
+		panic(fmt.Sprintf("unsupported TypeClause %T", tcl))
+	}
+}

--- a/internal/ecs/core.go
+++ b/internal/ecs/core.go
@@ -27,7 +27,7 @@ type ComponentType uint64
 // handed out by AddEntity.
 const NoType ComponentType = 0
 
-func (t ComponentType) String() string { return fmt.Sprintf("<%016x>", uint64(t)) }
+func (t ComponentType) String() string { return fmt.Sprintf("%016x", uint64(t)) }
 
 // All returns true only if all of the masked type bits are set. If the mask is
 // NoType, always returns false.

--- a/internal/ecs/core.go
+++ b/internal/ecs/core.go
@@ -29,13 +29,13 @@ const NoType ComponentType = 0
 
 func (t ComponentType) String() string { return fmt.Sprintf("%016x", uint64(t)) }
 
-// All returns true only if all of the masked type bits are set. If the mask is
-// NoType, always returns false.
-func (t ComponentType) All(mask ComponentType) bool { return mask != NoType && t&mask == mask }
+// HasAll returns true only if all of the masked type bits are set. If the mask
+// is NoType, always returns false.
+func (t ComponentType) HasAll(mask ComponentType) bool { return mask != NoType && t&mask == mask }
 
-// Any returns true only if at least one of the masked type bits is set. If the
+// HasAny returns true only if at least one of the masked type bits is set. If the
 // mask is NoType, always returns true.
-func (t ComponentType) Any(mask ComponentType) bool { return mask == NoType || t&mask != 0 }
+func (t ComponentType) HasAny(mask ComponentType) bool { return mask == NoType || t&mask != 0 }
 
 // ApplyTo sets the given entity's type to t; simply a dual of Entity.SetType.
 func (t ComponentType) ApplyTo(ent Entity) { ent.SetType(t) }
@@ -84,7 +84,7 @@ func (co *Core) Clear() {
 // corresponding element(s).
 func (co *Core) RegisterAllocator(t ComponentType, allocator func(EntityID, ComponentType)) {
 	for _, ef := range co.allocators {
-		if ef.t.Any(t) {
+		if ef.t.HasAny(t) {
 			panic("aspect type conflict")
 		}
 	}

--- a/internal/ecs/ecs_test.go
+++ b/internal/ecs/ecs_test.go
@@ -81,7 +81,7 @@ func TestBasics(t *testing.T) {
 
 func TestIter_empty(t *testing.T) {
 	s := newStuff()
-	it := s.Iter(ecs.AllClause)
+	it := s.Iter(ecs.TrueClause)
 	assert.Equal(t, 0, it.Count())
 
 	assert.False(t, it.Next())
@@ -96,7 +96,7 @@ func TestIter_one(t *testing.T) {
 	s1 := s.AddEntity(scData)
 	s.d1[s1.ID()] = 3
 
-	it := s.Iter(ecs.AllClause)
+	it := s.Iter(ecs.TrueClause)
 	assert.Equal(t, 1, it.Count())
 
 	assert.True(t, it.Next())
@@ -119,7 +119,7 @@ func TestIter_two(t *testing.T) {
 	s.d1[e2.ID()] = 4
 	s.d2[e2.ID()] = append(s.d2[e2.ID()], 2, 2, 3, 5, 8)
 
-	it := s.Iter(ecs.AllClause)
+	it := s.Iter(ecs.TrueClause)
 	assert.Equal(t, 2, it.Count())
 
 	// iterate all 3
@@ -139,7 +139,7 @@ func TestIter_two(t *testing.T) {
 	assert.Equal(t, ecs.NoType, it.Type())
 
 	// filtering
-	it = s.Iter(ecs.All(scD2))
+	it = s.Iter(scD2.MatchAll())
 	assert.Equal(t, 1, it.Count())
 
 	assert.True(t, it.Next())

--- a/internal/ecs/ecs_test.go
+++ b/internal/ecs/ecs_test.go
@@ -139,7 +139,7 @@ func TestIter_two(t *testing.T) {
 	assert.Equal(t, ecs.NoType, it.Type())
 
 	// filtering
-	it = s.Iter(scD2.MatchAll())
+	it = s.Iter(scD2.All())
 	assert.Equal(t, 1, it.Count())
 
 	assert.True(t, it.Next())

--- a/internal/ecs/employee_example_test.go
+++ b/internal/ecs/employee_example_test.go
@@ -130,7 +130,7 @@ func Example_employees() {
 
 	// pull some ids out
 	var ids []ecs.EntityID
-	for it := shop.Iter(personInfo.MatchAll()); it.Next(); {
+	for it := shop.Iter(personInfo.All()); it.Next(); {
 		ids = append(ids, it.ID())
 	}
 

--- a/internal/ecs/employee_example_test.go
+++ b/internal/ecs/employee_example_test.go
@@ -130,7 +130,7 @@ func Example_employees() {
 
 	// pull some ids out
 	var ids []ecs.EntityID
-	for it := shop.Iter(ecs.All(personInfo)); it.Next(); {
+	for it := shop.Iter(personInfo.MatchAll()); it.Next(); {
 		ids = append(ids, it.ID())
 	}
 

--- a/internal/ecs/entity.go
+++ b/internal/ecs/entity.go
@@ -18,7 +18,7 @@ func (ent Entity) String() string {
 	if ent.co == nil {
 		return fmt.Sprintf("%p<>[%v]", ent.co, ent.id)
 	}
-	return fmt.Sprintf("%p%v[%v]",
+	return fmt.Sprintf("%p<%v>[%v]",
 		ent.co,
 		ent.co.types[ent.id-1],
 		ent.id,

--- a/internal/ecs/entity.go
+++ b/internal/ecs/entity.go
@@ -144,14 +144,14 @@ func (co *Core) setType(id EntityID, new ComponentType) {
 	}
 	if created != 0 {
 		for _, ef := range co.creators {
-			if new.All(ef.t) && !old.All(ef.t) {
+			if new.HasAll(ef.t) && !old.HasAll(ef.t) {
 				ef.f(id, new)
 			}
 		}
 	}
 	if destroyed != 0 {
 		for _, ef := range co.destroyers {
-			if old.All(ef.t) && !new.All(ef.t) {
+			if old.HasAll(ef.t) && !new.HasAll(ef.t) {
 				ef.f(id, new)
 			}
 		}

--- a/internal/ecs/iter.go
+++ b/internal/ecs/iter.go
@@ -18,7 +18,7 @@ type Iterator struct {
 func (it *Iterator) Next() bool {
 	for it.i++; it.i < len(it.co.types); it.i++ {
 		t := it.co.types[it.i]
-		if it.tcl.Test(t) {
+		if it.tcl.test(t) {
 			return true
 		}
 	}


### PR DESCRIPTION
I've been growing increasingly dissatisfied with this part of Execs's ecs.

I believe that performance can be recovered by compiling back to a concrete struct when possible for linear scans, and by leveraging a type index within ecs.Core to better "plan" an iterator.