### PR TITLE
Unify ECS Relation read path

### DIFF
--- a/internal/ecs/clause.go
+++ b/internal/ecs/clause.go
@@ -7,6 +7,7 @@ import (
 
 // TypeClause is a logical filter for ComponentTypes.
 type TypeClause interface {
+	CursorOpt
 	test(ComponentType) bool
 	// TODO this is a convenient place to start, but to make it perform, we'll
 	// need to compile to a tighter for linear scan and/or to proper planning

--- a/internal/ecs/ecs_test.go
+++ b/internal/ecs/ecs_test.go
@@ -31,6 +31,17 @@ func newStuff() *stuff {
 	return s
 }
 
+func (s *stuff) addData(d1 int, d2 ...int) ecs.Entity {
+	ent := s.AddEntity(scData)
+	id := ent.ID()
+	s.d1[id] = d1
+	if len(d2) > 0 {
+		ent.Add(scD2)
+		s.d2[id] = append(s.d2[id], d2...)
+	}
+	return ent
+}
+
 func (s *stuff) allocData(id ecs.EntityID, t ecs.ComponentType) {
 	s.d1 = append(s.d1, 0)
 	s.d2 = append(s.d2, nil)

--- a/internal/ecs/employee_example_test.go
+++ b/internal/ecs/employee_example_test.go
@@ -281,7 +281,7 @@ func Example_employees() {
 	amt.assign()
 
 	fmt.Printf("assignments:\n")
-	for cur := amt.Cursor(amtWorking.All()); cur.Scan(); {
+	for cur := amt.Select(amtWorking.All()); cur.Scan(); {
 		worker, job := cur.A(), cur.B()
 		ws := wrk.skills[worker.ID()]
 		js := jb.skills[job.ID()]

--- a/internal/ecs/relation.go
+++ b/internal/ecs/relation.go
@@ -94,24 +94,17 @@ func (rel *Relation) destroyFromB(bid EntityID, t ComponentType) {
 	}
 }
 
-// Cursor returns a cursor that will scan over relations that match the given type clause.
-func (rel *Relation) Cursor(tcl TypeClause) Cursor {
-	it := rel.Iter(tcl)
-	return &iterCursor{rel: rel, it: it}
-}
-
-// LookupA returns a Cursor that will iterate over relations involving one or
-// more given A entities.
-func (rel *Relation) LookupA(tcl TypeClause, ids ...EntityID) Cursor {
-	// TODO: indexing
-	return rel.scanLookup(tcl, false, ids)
-}
-
-// LookupB returns a Cursor that will iterate over relations involving one or
-// more given B entities.
-func (rel *Relation) LookupB(tcl TypeClause, ids ...EntityID) Cursor {
-	// TODO: indexing
-	return rel.scanLookup(tcl, true, ids)
+// Select creates a cursor with the given options applied. If none are given,
+// TrueClause is used; so the default is basically "select all".
+func (rel *Relation) Select(opts ...CursorOpt) Cursor {
+	if len(opts) == 0 {
+		return TrueClause.apply(rel, nil)
+	}
+	cur := opts[0].apply(rel, nil)
+	for _, opt := range opts[1:] {
+		cur = opt.apply(rel, cur)
+	}
+	return cur
 }
 
 // Upsert updates any relations that the given cursor iterates, and may insert

--- a/internal/ecs/relation_test.go
+++ b/internal/ecs/relation_test.go
@@ -8,44 +8,49 @@ import (
 	"github.com/borkshop/bork/internal/ecs"
 )
 
+const (
+	srFoo ecs.ComponentType = 1 << iota
+	srBar
+)
+
 func setupRelTest(aFlags, bFlags ecs.RelationFlags) (a, b *stuff, rel *ecs.Relation) {
 	a = newStuff()
-	a1 := a.AddEntity(scData)
-	a2 := a.AddEntity(scData)
-	a3 := a.AddEntity(scData)
-	a4 := a.AddEntity(scData)
-	a5 := a.AddEntity(scData)
-	a6 := a.AddEntity(scData)
-	a7 := a.AddEntity(scData)
-	_ = a.AddEntity(scData) // a8
+	a1 := a.addData(3)
+	a2 := a.addData(6)
+	a3 := a.addData(9)
+	a4 := a.addData(12)
+	a5 := a.addData(15, 30, 45, 60)
+	a6 := a.addData(18)
+	a7 := a.addData(21)
+	_ = a.addData(24) // a8
 
 	b = newStuff()
-	b1 := b.AddEntity(scData)
-	b2 := b.AddEntity(scData)
-	b3 := b.AddEntity(scData)
-	b4 := b.AddEntity(scData)
-	b5 := b.AddEntity(scData)
-	b6 := b.AddEntity(scData)
-	b7 := b.AddEntity(scData)
-	_ = b.AddEntity(scData) // b8
+	b1 := b.addData(5)
+	b2 := b.addData(10, 20, 30, 40)
+	b3 := b.addData(15)
+	b4 := b.addData(20, 40, 60, 80)
+	b5 := b.addData(25)
+	b6 := b.addData(30, 60, 90, 120)
+	b7 := b.addData(35)
+	_ = b.addData(40, 80, 120, 160) // b8
 
 	rel = ecs.NewRelation(&a.Core, aFlags, &b.Core, bFlags)
 
 	rel.Upsert(nil, func(uc *ecs.UpsertCursor) {
 
-		uc.Create(1, a1, b2)
-		uc.Create(1, a1, b3)
-		uc.Create(1, a2, b4)
-		uc.Create(1, a2, b5)
-		uc.Create(1, a3, b6)
-		uc.Create(1, a3, b7)
+		uc.Create(srFoo, a1, b2)
+		uc.Create(srFoo, a1, b3)
+		uc.Create(srFoo, a2, b4)
+		uc.Create(srFoo, a2, b5)
+		uc.Create(srFoo, a3, b6)
+		uc.Create(srFoo, a3, b7)
 
-		uc.Create(1, a2, b1)
-		uc.Create(1, a3, b1)
-		uc.Create(1, a4, b2)
-		uc.Create(1, a5, b2)
-		uc.Create(1, a6, b3)
-		uc.Create(1, a7, b3)
+		uc.Create(srFoo|srBar, a2, b1)
+		uc.Create(srFoo|srBar, a3, b1)
+		uc.Create(srFoo|srBar, a4, b2)
+		uc.Create(srFoo|srBar, a5, b2)
+		uc.Create(srFoo|srBar, a6, b3)
+		uc.Create(srFoo|srBar, a7, b3)
 
 	})
 


### PR DESCRIPTION
Unify `Cursor()`, `LookupA()`, and `LookupB()` around an options interface:
- `TypeClause` is now (the primary?) cursor option
- `Relation.LookupA(ids...)` is now `InA(ids...)` (resp B)
- reprised `where func(...) bool` as a `CursorFilter(func(Cursor) bool` option