### PR TITLE
Add showroom proof of concept

### DIFF
--- a/internal/hilbert/hilbert.go
+++ b/internal/hilbert/hilbert.go
@@ -1,0 +1,49 @@
+package hilbert
+
+import "image"
+
+type Scale int
+
+func (scale Scale) Encode(pt image.Point) int {
+	return Encode(pt, int(scale))
+}
+
+func (scale Scale) Decode(hi int) image.Point {
+	return Decode(hi, int(scale))
+}
+
+func Encode(pt image.Point, scale int) int {
+	var rotation image.Point
+	h := 0
+	for s := scale >> 1; s > 0; s >>= 1 {
+		rotation.X = pt.X & s
+		rotation.Y = pt.Y & s
+		h += s * ((3 * rotation.X) ^ rotation.Y)
+		pt = rotate(pt, s, rotation)
+	}
+	return h
+}
+
+func Decode(h int, scale int) image.Point {
+	var pt, rotation image.Point
+	for s := 1; s < scale; s <<= 1 {
+		rotation.X = 1 & h >> 1
+		rotation.Y = 1 & (h ^ rotation.X)
+		pt = rotate(pt, scale, rotation)
+		rotation = rotation.Mul(s)
+		pt = pt.Add(rotation)
+		h >>= 2
+	}
+	return pt
+}
+
+func rotate(pt image.Point, scale int, rotation image.Point) image.Point {
+	if rotation.Y == 0 {
+		if rotation.X != 0 {
+			pt.X = scale - 1 - pt.X
+			pt.Y = scale - 1 - pt.Y
+		}
+		pt.X, pt.Y = pt.Y, pt.X
+	}
+	return pt
+}

--- a/proofs/showroom/main.go
+++ b/proofs/showroom/main.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"os"
+
+	"github.com/borkshop/bork/internal/cops/display"
+	"github.com/borkshop/bork/internal/cops/terminal"
+	"github.com/borkshop/bork/internal/hilbert"
+	opensimplex "github.com/ojrac/opensimplex-go"
+)
+
+func main() {
+	if err := Main(); err != nil {
+		fmt.Printf("%v\n", err)
+	}
+}
+
+var (
+	white = color.RGBA{192, 198, 187, 255}
+	blue  = color.RGBA{2, 50, 145, 255}
+)
+
+func Main() error {
+
+	term := terminal.New(os.Stdout.Fd())
+	defer term.Restore()
+	term.SetRaw()
+
+	bounds, err := term.Bounds()
+	if err != nil {
+		return err
+	}
+
+	world := newWorld()
+
+	front, back := display.New2(bounds)
+
+	var buf []byte
+	cur := display.Start
+	buf, cur = cur.Home(buf)
+	buf, cur = cur.Clear(buf)
+	buf, cur = cur.Hide(buf)
+
+	var at image.Point
+
+Loop:
+	for {
+		world.Draw(front, at)
+
+		buf, cur = display.Render(buf, cur, front, display.Model24)
+		buf, cur = cur.Reset(buf)
+		front, back = back, front
+		os.Stdout.Write(buf)
+		buf = buf[0:0]
+
+		var rbuf [1]byte
+		os.Stdin.Read(rbuf[0:1])
+
+		switch rbuf[0] {
+		// case ' ':
+		// 	back.Clear(back.Bounds())
+		case 'q':
+			break Loop
+
+		case 'j':
+			at.Y++
+		case 'k':
+			at.Y--
+		case 'h':
+			at.X--
+		case 'l':
+			at.X++
+
+		case 'J':
+			at.Y += bounds.Dy()
+		case 'K':
+			at.Y -= bounds.Dy()
+		case 'H':
+			at.X -= bounds.Dx()
+		case 'L':
+			at.X += bounds.Dx()
+
+		case ' ':
+			buf, cur = cur.Clear(buf)
+			back.Clear(back.Bounds())
+		}
+
+		if at.X < 0 {
+			at.X = 0
+		}
+		if at.Y < 0 {
+			at.Y = 0
+		}
+
+	}
+
+	buf, cur = cur.Home(buf)
+	buf, cur = cur.Clear(buf)
+	buf, cur = cur.Show(buf)
+	os.Stdout.Write(buf)
+	buf = buf[0:0]
+	return nil
+}
+
+func newWorld() *World {
+	noise := opensimplex.NewWithSeed(0)
+	return &World{
+		noise: noise,
+	}
+}
+
+type World struct {
+	noise *opensimplex.Noise
+}
+
+type tileType int
+
+const (
+	scale         = 1 << 30
+	hstride       = 10
+	vstride       = 6
+	wallThickness = 1
+)
+
+const (
+	room tileType = iota
+	horizontal
+	vertical
+	corner
+)
+
+func (w World) tileType(x, y int) tileType {
+	var t tileType
+	if x%hstride < wallThickness {
+		t |= 1
+	}
+	if y%vstride < wallThickness {
+		t |= 2
+	}
+	return t
+}
+
+func (w World) tileAt(x, y int) (int, int) {
+	return x / hstride, y / vstride
+}
+
+func (w World) colorAt(x, y int) color.Color {
+	rx, ry := w.tileAt(x, y)
+	at := hilbert.Encode(image.Pt(rx, ry), scale)
+
+	switch w.tileType(x, y) {
+	case vertical:
+		to := hilbert.Encode(image.Pt(rx, ry-1), scale)
+		if at+1 != to && at-1 != to {
+			return blue
+		}
+	case horizontal:
+		to := hilbert.Encode(image.Pt(rx-1, ry), scale)
+		if at+1 != to && at-1 != to {
+			return blue
+		}
+	case corner:
+		return blue
+	}
+
+	o := uint8(0)
+	if (x+y)&1 == 0 {
+		o = 5
+	}
+	n := w.noise.Eval2(float64(x), float64(y))
+	return color.Gray{uint8(n*10) + (255 - 15) + o}
+}
+
+func (w World) Draw(d *display.Display, about image.Point) {
+	// size := d.Bounds().Size()
+	// size.X /= 2
+	// rect := d.Bounds().Sub(size.Div(2))
+	rect := d.Bounds()
+	for y := rect.Min.Y; y < rect.Max.Y; y++ {
+		for x := rect.Min.X; x < rect.Max.X; x += 2 {
+			c := w.colorAt((x+about.X*2)/2, y+about.Y)
+			d.Set(x, y, " ", c, c)
+			d.Set(x+1, y, " ", c, c)
+		}
+	}
+}

--- a/proofs/showroom/main.go
+++ b/proofs/showroom/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	if err := Main(); err != nil {
+	if err := run(); err != nil {
 		fmt.Printf("%v\n", err)
 	}
 }
@@ -23,7 +23,7 @@ var (
 	blue  = color.RGBA{2, 50, 145, 255}
 )
 
-func Main() error {
+func run() error {
 
 	term := terminal.New(os.Stdout.Fd())
 	defer term.Restore()
@@ -105,14 +105,14 @@ Loop:
 	return nil
 }
 
-func newWorld() *World {
+func newWorld() *world {
 	noise := opensimplex.NewWithSeed(0)
-	return &World{
+	return &world{
 		noise: noise,
 	}
 }
 
-type World struct {
+type world struct {
 	noise *opensimplex.Noise
 }
 
@@ -132,22 +132,22 @@ const (
 	corner
 )
 
-func (w World) tileType(x, y int) tileType {
+func (w world) tileType(x, y int) tileType {
 	var t tileType
 	if x%hstride < wallThickness {
-		t |= 1
+		t |= horizontal
 	}
 	if y%vstride < wallThickness {
-		t |= 2
+		t |= vertical
 	}
 	return t
 }
 
-func (w World) tileAt(x, y int) (int, int) {
+func (w world) tileAt(x, y int) (int, int) {
 	return x / hstride, y / vstride
 }
 
-func (w World) colorAt(x, y int) color.Color {
+func (w world) colorAt(x, y int) color.Color {
 	rx, ry := w.tileAt(x, y)
 	at := hilbert.Encode(image.Pt(rx, ry), scale)
 
@@ -174,7 +174,7 @@ func (w World) colorAt(x, y int) color.Color {
 	return color.Gray{uint8(n*10) + (255 - 15) + o}
 }
 
-func (w World) Draw(d *display.Display, about image.Point) {
+func (w world) Draw(d *display.Display, about image.Point) {
 	// size := d.Bounds().Size()
 	// size.X /= 2
 	// rect := d.Bounds().Sub(size.Div(2))


### PR DESCRIPTION
This is a proof of concept of a Hilbert curve shaped showroom floor, explorable
in the terminal.

Run proofs/showroom/main.go

Use HJKL to pan over showroom (shift for display-wide motion)

<img width="1407" alt="screen shot 2017-12-09 at 8 45 10 pm" src="https://user-images.githubusercontent.com/60294/33802020-4d55768a-dd22-11e7-8097-337b55d3ac2a.png">