### PR TITLE
Sanify cops wrt transparency

### DIFF
--- a/internal/cops/display/display.go
+++ b/internal/cops/display/display.go
@@ -146,7 +146,7 @@ func (d *Display) At(x, y int) (t string, f, b color.Color) {
 // RGBAAt is a faster version of At.
 func (d *Display) RGBAAt(x, y int) (t string, f, b color.RGBA) {
 	if d == nil {
-		return "", Colors[7], color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+		return "", Colors[7], color.RGBA{}
 	}
 	if i := d.Text.StringsOffset(x, y); i >= 0 && i < len(d.Text.Strings) {
 		return d.rgbaati(i)

--- a/internal/cops/display/render_bench_test.go
+++ b/internal/cops/display/render_bench_test.go
@@ -66,7 +66,7 @@ func (sim *benchSim) generate() {
 			t := letters[sim.rand()%26]
 			r := sim.rand()
 			f := color.RGBA{R: uint8(r), G: uint8(r >> 8), B: uint8(r >> 16)}
-			b := color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+			b := color.RGBA{}
 			sim.SetRGBA(x, y, t, f, b)
 		}
 	}


### PR DESCRIPTION
Turns out that I confused "alpha" with "opacity" (yet again, keeping the two terms straight has been an ongoing challenge for me over the years...)

Anyhow, this PR has two things:
- fixes the benchmark I wrote, that I though was using "transparent"
- changes `Display.RGBAAt` (my source of reasoning by analogy when I first came into cops... apparently I missed the definition if `display.Transparent`); anyhow, I for one feel strongly that a nil display should be zero-valued everywhere, and that even makes more semantic sense being "transparent black" than "opaque white"; we're drawing on computers here, not paper ;-)