### PR TITLE
Add a cops draw test

### DIFF
--- a/internal/cops/display/draw_test.go
+++ b/internal/cops/display/draw_test.go
@@ -39,7 +39,7 @@ func TestDraw_centered(t *testing.T) {
 		"____xxxxxxxx____",
 		"________________",
 		"________________",
-	}, dst.Text.Lines("0"))
+	}, dst.Text.LinesWithFill("0"))
 
 	assert.Equal(t, []string{
 		"................",

--- a/internal/cops/display/draw_test.go
+++ b/internal/cops/display/draw_test.go
@@ -1,0 +1,91 @@
+package display_test
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/draw"
+	"testing"
+
+	. "github.com/borkshop/bork/internal/cops/display"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDraw_centered(t *testing.T) {
+	dst := New(image.Rect(0, 0, 16, 8))
+	src := New(image.Rect(0, 0, 8, 4))
+	dst.Fill(dst.Rect, "_", Colors[7], Colors[0])
+	src.Fill(src.Rect, "x", Colors[5], Colors[4])
+
+	bound, off := dst.Rect, image.ZP
+	if n := bound.Dx() - src.Rect.Dx(); n > 0 {
+		bound.Min.X += n / 2
+	} else if n < 0 {
+		off.X += n / 2
+	}
+	if n := bound.Dy() - src.Rect.Dy(); n > 0 {
+		bound.Min.Y += n / 2
+	} else if n < 0 {
+		off.Y += n / 2
+	}
+	Draw(dst, bound, src, off, draw.Over)
+
+	assert.Equal(t, []string{
+		"________________",
+		"________________",
+		"____xxxxxxxx____",
+		"____xxxxxxxx____",
+		"____xxxxxxxx____",
+		"____xxxxxxxx____",
+		"________________",
+		"________________",
+	}, dst.Text.Lines("0"))
+
+	assert.Equal(t, []string{
+		"................",
+		"................",
+		"....!!!!!!!!....",
+		"....!!!!!!!!....",
+		"....!!!!!!!!....",
+		"....!!!!!!!!....",
+		"................",
+		"................",
+	}, imageTestRepr(dst.Foreground, "0", map[color.RGBA]string{
+		Colors[7]: ".",
+		Colors[5]: "!",
+	}))
+
+	assert.Equal(t, []string{
+		"----------------",
+		"----------------",
+		"----########----",
+		"----########----",
+		"----########----",
+		"----########----",
+		"----------------",
+		"----------------",
+	}, imageTestRepr(dst.Background, "0", map[color.RGBA]string{
+		Colors[0]: "-",
+		Colors[4]: "#",
+	}))
+}
+
+func imageTestRepr(img *image.RGBA, dflt string, c2s map[color.RGBA]string) (r []string) {
+	r = make([]string, img.Rect.Dy())
+	nx := img.Rect.Dx()
+	img.Bounds()
+	var buf bytes.Buffer
+	for y := 0; y < len(r); y++ {
+		buf.Reset()
+		for x := 0; x < nx; x++ {
+			c := img.RGBAAt(x, y)
+			s := c2s[c]
+			if s == "" {
+				s = dflt
+			}
+			_, _ = buf.WriteString(s)
+		}
+		r[y] = buf.String()
+	}
+	return r
+}

--- a/internal/cops/textile/textile.go
+++ b/internal/cops/textile/textile.go
@@ -97,3 +97,29 @@ func (t *Textile) SubText(r image.Rectangle) *Textile {
 func (t *Textile) StringsOffset(x, y int) int {
 	return (y-t.Rect.Min.Y)*t.Stride + (x - t.Rect.Min.X)
 }
+
+// Lines returns a slice of row strings from the textile, filling in any empty
+// strings with the given one.
+func (t Textile) Lines(fillZero string) []string {
+	lines := make([]string, t.Rect.Max.Y)
+	line := make([]byte, 0, t.Rect.Dx())
+	y := t.Rect.Min.Y
+	for ; y < t.Rect.Max.Y; y++ {
+		line = line[:0]
+		x := t.Rect.Min.X
+		i := t.StringsOffset(x, y)
+		j := 0
+		for ; x < t.Rect.Max.X; x++ {
+			if ch := t.Strings[i]; ch != "" {
+				line = append(line, ch...)
+				j += len(ch)
+			} else {
+				line = append(line, fillZero...)
+				j += len(fillZero)
+			}
+			i++
+		}
+		lines[y] = string(line[:j])
+	}
+	return lines
+}

--- a/internal/cops/textile/textile.go
+++ b/internal/cops/textile/textile.go
@@ -98,9 +98,14 @@ func (t *Textile) StringsOffset(x, y int) int {
 	return (y-t.Rect.Min.Y)*t.Stride + (x - t.Rect.Min.X)
 }
 
-// Lines returns a slice of row strings from the textile, filling in any empty
+// Lines returns a slice of row strings from the textile.
+func (t Textile) Lines() []string {
+	return t.LinesWithFill(" ")
+}
+
+// LinesWithFill returns a slice of row strings from the textile, filling in any empty
 // strings with the given one.
-func (t Textile) Lines(fillZero string) []string {
+func (t Textile) LinesWithFill(fillZero string) []string {
 	lines := make([]string, t.Rect.Max.Y)
 	line := make([]byte, 0, t.Rect.Dx())
 	y := t.Rect.Min.Y


### PR DESCRIPTION
First working base case; next step is to generalize and cover cases like:
- src > dst
- src == dst
- off-by-one boundaries from those
- asymmetric src v dst

Past that, and especially if getting through all of that doesn't clear up #31's path, a stateful test with a growing/shrinking src against static dst; maybe integrated through rendering...