### PR TITLE
Improve ecs.Core.Iter ergonomics

### DIFF
--- a/internal/ecs/ecs_test.go
+++ b/internal/ecs/ecs_test.go
@@ -92,7 +92,7 @@ func TestBasics(t *testing.T) {
 
 func TestIter_empty(t *testing.T) {
 	s := newStuff()
-	it := s.Iter(ecs.TrueClause)
+	it := s.Iter()
 	assert.Equal(t, 0, it.Count())
 
 	assert.False(t, it.Next())
@@ -107,7 +107,7 @@ func TestIter_one(t *testing.T) {
 	s1 := s.AddEntity(scData)
 	s.d1[s1.ID()] = 3
 
-	it := s.Iter(ecs.TrueClause)
+	it := s.Iter()
 	assert.Equal(t, 1, it.Count())
 
 	assert.True(t, it.Next())
@@ -130,7 +130,7 @@ func TestIter_two(t *testing.T) {
 	s.d1[e2.ID()] = 4
 	s.d2[e2.ID()] = append(s.d2[e2.ID()], 2, 2, 3, 5, 8)
 
-	it := s.Iter(ecs.TrueClause)
+	it := s.Iter()
 	assert.Equal(t, 2, it.Count())
 
 	// iterate all 3

--- a/internal/ecs/employee_example_test.go
+++ b/internal/ecs/employee_example_test.go
@@ -203,10 +203,7 @@ func (wrk *workers) unassigned() ecs.Iterator {
 }
 
 func (jb *jobs) unassigned() ecs.Iterator {
-	return jb.Iter(ecs.And(
-		(jobInfo | jobWork).All(),
-		jobAssigned.NotAny(),
-	))
+	return jb.Iter((jobInfo | jobWork).All(), jobAssigned.NotAny())
 }
 
 func (amt *assignment) assign() {

--- a/internal/ecs/iter.go
+++ b/internal/ecs/iter.go
@@ -1,8 +1,17 @@
 package ecs
 
-// Iter returns a new iterator over the Core's entities which satisfy the
-// given TypeClause.
-func (co *Core) Iter(tcl TypeClause) Iterator { return Iterator{co, -1, tcl} }
+// Iter returns a new iterator over the Core's entities which satisfy all of
+// given TypeClause(s).
+func (co *Core) Iter(tcls ...TypeClause) Iterator {
+	switch len(tcls) {
+	case 0:
+		return &coreIterator{co, -1, TrueClause}
+	case 1:
+		return &coreIterator{co, -1, tcls[0]}
+	default:
+		return &coreIterator{co, -1, And(tcls...)}
+	}
+}
 
 // Iterator points into a Core's entities, iterating over them with optional
 // type filter criteria.

--- a/internal/ecs/time/example_test.go
+++ b/internal/ecs/time/example_test.go
@@ -49,7 +49,7 @@ func (w *world) init() {
 
 func (w *world) dump() {
 	fmt.Printf("now=%v\n", w.time.Now())
-	for it := w.Iter(ecs.TrueClause); it.Next(); {
+	for it := w.Iter(); it.Next(); {
 		if it.Type() != ecs.NoType {
 			fmt.Printf("- [%v]<%v>\n", it.ID(), it.Type())
 		}

--- a/proofs/deathroom/ai.go
+++ b/proofs/deathroom/ai.go
@@ -116,7 +116,7 @@ func (w *world) scoreAIGoal(ai, goal ecs.Entity) int {
 func (w *world) chooseAIGoal(ai ecs.Entity) ecs.Entity {
 	// TODO: doesn't always cause progress, get stuck on the edge sometimes
 	goal, sum := ecs.NilEntity, 0
-	for it := w.Iter(ecs.And(wcSolid.All(), wcBody.NotAll())); it.Next(); {
+	for it := w.Iter(wcSolid.All(), wcBody.NotAll()); it.Next(); {
 		if score := w.scoreAIGoal(ai, it.Entity()); score > 0 {
 			sum += score
 			if sum <= 0 || w.rng.Intn(sum) < score {

--- a/proofs/deathroom/body_test.go
+++ b/proofs/deathroom/body_test.go
@@ -81,7 +81,7 @@ func TestBody_sever_vital(t *testing.T) {
 			severed := bo.sever(t.Logf, part)
 			require.NotNil(t, severed)
 
-			it = severed.Iter(ecs.TrueClause)
+			it = severed.Iter()
 			got := make([]string, 0, it.Count())
 			for it.Next() {
 				got = append(got, severed.DescribePart(it.Entity()))

--- a/proofs/deathroom/main.go
+++ b/proofs/deathroom/main.go
@@ -443,7 +443,7 @@ func (w *world) maybeSpawn() {
 	}
 
 	totalHP, totalDmg, combatCount := 0, 0, 0
-	for it := w.Iter(ecs.And((wcSolid | wcBody | wcInput).All(), wcWaiting.NotAll())); it.Next(); {
+	for it := w.Iter((wcSolid | wcBody | wcInput).All(), wcWaiting.NotAll()); it.Next(); {
 		combatCount++
 		bo := w.bodies[it.ID()]
 		if it.Type().HasAll(wcSoul) {

--- a/proofs/deathroom/ui.go
+++ b/proofs/deathroom/ui.go
@@ -556,7 +556,7 @@ func (w *world) renderViewport(max point.Point) view.Grid {
 	zVals := make([]uint8, len(grid.Data))
 
 	// TODO: use an pos range query
-	for it := w.Iter(ecs.And(wcPosition.All(), (wcGlyph | wcBG).Any())); it.Next(); {
+	for it := w.Iter(wcPosition.All(), (wcGlyph | wcBG).Any()); it.Next(); {
 		pos, _ := w.pos.Get(it.Entity())
 		pos = pos.Add(offset)
 		gi := pos.Y*grid.Size.X + pos.X


### PR DESCRIPTION
Allow passing variable, including no, type clauses to `Core.Iter()`:
- none means all
- more than one `and`s together