### PR TITLE
Fix rectangle.Capture off-by-one

### DIFF
--- a/internal/rectangle/rectangle.go
+++ b/internal/rectangle/rectangle.go
@@ -34,14 +34,14 @@ func Capture(r image.Rectangle, pt image.Point) image.Rectangle {
 	if pt.X < r.Min.X {
 		r.Min.X = pt.X
 	}
-	if pt.X > r.Max.X {
-		r.Max.X = pt.X
+	if pt.X >= r.Max.X {
+		r.Max.X = pt.X + 1
 	}
 	if pt.Y < r.Min.Y {
 		r.Min.Y = pt.Y
 	}
-	if pt.Y > r.Max.Y {
-		r.Max.Y = pt.Y
+	if pt.Y >= r.Max.Y {
+		r.Max.Y = pt.Y + 1
 	}
 	return r
 }


### PR DESCRIPTION
Per the docs, `image.Rectangle` min/max work as a half-open interval; so before this PR, if you start out with a zero rectangle, and add one point, you still have `Dx() == 0` and `Dy() == 0`.