### PR TITLE
EPS improvements and ZFrame

### DIFF
--- a/internal/ecs/eps/ems.go
+++ b/internal/ecs/eps/ems.go
@@ -243,12 +243,18 @@ func (mov *Moves) runMove(
 
 // Pending returns a relation cursor over all pending moves; thse are either
 // unprocessed moves, or leftover/unused magnitudes.
-func (mov *Moves) Pending() ecs.Cursor {
-	return mov.Select(movRelPending.All())
+func (mov *Moves) Pending(opts ...ecs.CursorOpt) ecs.Cursor {
+	sopts := make([]ecs.CursorOpt, 1, 1+len(opts))
+	sopts[0] = movRelPending.All()
+	sopts = append(sopts, opts...)
+	return mov.Select(sopts...)
 }
 
 // Collisions returns a relation cursor over all collisions from the last
 // processing round.
-func (mov *Moves) Collisions() ecs.Cursor {
-	return mov.Select(movRelCollide.All())
+func (mov *Moves) Collisions(opts ...ecs.CursorOpt) ecs.Cursor {
+	sopts := make([]ecs.CursorOpt, 1, 1+len(opts))
+	sopts[0] = movRelCollide.All()
+	sopts = append(sopts, opts...)
+	return mov.Select(sopts...)
 }

--- a/internal/ecs/eps/eps.go
+++ b/internal/ecs/eps/eps.go
@@ -11,11 +11,6 @@ import (
 	"github.com/borkshop/bork/internal/rectangle"
 )
 
-// TODO support movement on top of or within an EPS:
-// - an ecs.Relation on positioned things:
-//   - intent: direction & magnitude? jumping?
-//   - outcome: collision (only if solid)? pre-compute "what's here"?
-
 // EPS is an Entity Positioning System; (technically it's not an ecs.System, it
 // just has a reference to an ecs.Core).
 type EPS struct {

--- a/internal/ecs/eps/eps.go
+++ b/internal/ecs/eps/eps.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/borkshop/bork/internal/ecs"
+	"github.com/borkshop/bork/internal/point"
 )
 
 // TODO support movement on top of or within an EPS:
@@ -41,6 +42,25 @@ func (eps *EPS) Init(core *ecs.Core, t ecs.ComponentType) {
 	eps.core.RegisterAllocator(eps.t, eps.alloc)
 	eps.core.RegisterCreator(eps.t, eps.create)
 	eps.core.RegisterDestroyer(eps.t, eps.destroy)
+}
+
+// Bounds returns the bounding box containing all defined points.
+func (eps *EPS) Bounds() (box image.Rectangle) {
+	// TODO exploit the z-curve to do better and/or cache/pre-compute
+	it := eps.Iter()
+	for it.Next() {
+		if i := it.ID() - 1; eps.ix.flg[i]&epsDef != 0 {
+			box.Min = eps.pt[i]
+			box.Max = box.Min.Add(image.Pt(1, 1))
+			break
+		}
+	}
+	for it.Next() {
+		if i := it.ID() - 1; eps.ix.flg[i]&epsDef != 0 {
+			box = rectangle.Capture(box, eps.pt[i])
+		}
+	}
+	return box
 }
 
 // Get the position of an entity; the bool argument is true only if

--- a/internal/point/zorder.go
+++ b/internal/point/zorder.go
@@ -1,0 +1,27 @@
+package point
+
+import (
+	"image"
+)
+
+// ZFrame represents a frame of reference for computing Z-Curve keys.
+type ZFrame struct {
+	Bounds image.Rectangle
+}
+
+// Key packs a point into a z-curve key; if the point is outside the bounding
+// box, then Key(bounds.Max) is returned.
+func (zf ZFrame) Key(pt image.Point) (z uint64) {
+	if !pt.In(zf.Bounds) {
+		pt = zf.Bounds.Max
+	}
+	pt = pt.Sub(zf.Bounds.Min)
+	// TODO: evaluate a table ala
+	// https://graphics.stanford.edu/~seander/bithacks.html#InterleaveTableObvious
+	x, y := uint32(pt.X), uint32(pt.Y)
+	for i := uint(0); i < 32; i++ {
+		z |= uint64(x&(1<<i)) << i
+		z |= uint64(y&(1<<i)) << (i + 1)
+	}
+	return z
+}

--- a/internal/point/zorder.go
+++ b/internal/point/zorder.go
@@ -25,3 +25,14 @@ func (zf ZFrame) Key(pt image.Point) (z uint64) {
 	}
 	return z
 }
+
+// Point unpacks a z-curve key into a point.
+func (zf ZFrame) Point(z uint64) image.Point {
+	var x, y uint64
+	for i := uint(0); i < 32; i++ {
+		j := 2 * i
+		x |= (z & (1 << j)) >> i
+		y |= (z & (1 << (j + 1))) >> (i + 1)
+	}
+	return image.Pt(int(x), int(y)).Add(zf.Bounds.Min)
+}


### PR DESCRIPTION
While chasing workroom I did a bit of tweaking to the EPS, and pulled out its core z-curve logic for re-use outside of it.

I've now come to suspect that the EPS's core valuable piece is its secondary index, but that that part should be decoupled from the storage of mechanism (i.e. not tied to an `[]image.Point` that 1:1 maps with entities). E.g. I'd really like to experiment with a `[]Cell` (for some `Cell` type that's a struct with say position, glyph, fg, and bg) that could may 1:N with entities (e.g. so that entities can have more than one cell without resorting to a relation).